### PR TITLE
remove git:github.com from readme installation guide

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ A minimalist, versatile and opinionated theme for tmux.
 ## Installing
 Using [tpm](https://github.com/tmux-plugins/tpm), add this to your `tmux.conf`
 ```sh
-set -g @plugin 'git@github.com:bettervim/shifter'
+set -g @plugin 'bettervim/shifter'
 set -g @shifter_theme 'nord'
 ```
 


### PR DESCRIPTION
I guess I fixed a typo. I removed 'git@github.com' from your installation guide.

p.s. This theme will get famous.